### PR TITLE
Lots of fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@sentry/node": "^6.19.2",
+        "@snyk/protect": "^1.984.0",
         "body-parser": "^1.19.2",
         "browser-detect": "^0.2.28",
         "chunk": "0.0.3",
@@ -416,6 +417,17 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@snyk/protect": {
+      "version": "1.984.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.984.0.tgz",
+      "integrity": "sha512-R+XQotaoMVBBkAfzDQqO/hcUYlMHKjxXNjeMhlvSjnD4cR8IOrC+XTPyAO2l5v7L81wBMkKjCJ10YQwB6xYISg==",
+      "bin": {
+        "snyk-protect": "bin/snyk-protect"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -1828,13 +1840,13 @@
       "dev": true
     },
     "node_modules/ejs-lint": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ejs-lint/-/ejs-lint-1.2.1.tgz",
-      "integrity": "sha512-pHN8kjh8a4HxeG8FKl4+8wgiX/h7fiZK9r56hK2KA9xJ2a+736+4iEfEYw6uHkTy0rXdVGDSQFqpiFqG80TtKg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ejs-lint/-/ejs-lint-1.2.2.tgz",
+      "integrity": "sha512-ESR/MePvJJJfkK3EUAYlPKe2JM2nRDc4uFkGgbB5Prr06nluN7JozNVFL3Ze7LV7xNY7JPWEi5H3i4hOl6mxXw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "ejs": "3.1.6",
+        "ejs": "3.1.7",
         "ejs-include-regex": "^1.0.0",
         "globby": "^11.0.0",
         "read-input": "^0.3.1",
@@ -1844,21 +1856,6 @@
       },
       "bin": {
         "ejslint": "cli.js"
-      }
-    },
-    "node_modules/ejs-lint/node_modules/ejs": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-      "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
-      "dev": true,
-      "dependencies": {
-        "jake": "^10.6.1"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -3453,9 +3450,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }
@@ -3595,9 +3592,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.3.tgz",
-      "integrity": "sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -3896,9 +3893,9 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.2.tgz",
-      "integrity": "sha512-w9n/Ot5I7orGD4y+7V3EFJCQEznE5RxHamUxcqLT2QoJY0f2JdN8GyHonYFvN0Vz+L6lUJfVhrk2aZz2LbuREw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"
@@ -5764,6 +5761,11 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
     },
+    "@snyk/protect": {
+      "version": "1.984.0",
+      "resolved": "https://registry.npmjs.org/@snyk/protect/-/protect-1.984.0.tgz",
+      "integrity": "sha512-R+XQotaoMVBBkAfzDQqO/hcUYlMHKjxXNjeMhlvSjnD4cR8IOrC+XTPyAO2l5v7L81wBMkKjCJ10YQwB6xYISg=="
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -6913,30 +6915,19 @@
       "dev": true
     },
     "ejs-lint": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ejs-lint/-/ejs-lint-1.2.1.tgz",
-      "integrity": "sha512-pHN8kjh8a4HxeG8FKl4+8wgiX/h7fiZK9r56hK2KA9xJ2a+736+4iEfEYw6uHkTy0rXdVGDSQFqpiFqG80TtKg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ejs-lint/-/ejs-lint-1.2.2.tgz",
+      "integrity": "sha512-ESR/MePvJJJfkK3EUAYlPKe2JM2nRDc4uFkGgbB5Prr06nluN7JozNVFL3Ze7LV7xNY7JPWEi5H3i4hOl6mxXw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "ejs": "3.1.6",
+        "ejs": "3.1.7",
         "ejs-include-regex": "^1.0.0",
         "globby": "^11.0.0",
         "read-input": "^0.3.1",
         "slash": "^3.0.0",
         "syntax-error": "^1.1.6",
         "yargs": "^16.0.0"
-      },
-      "dependencies": {
-        "ejs": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
-          "integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
-          "dev": true,
-          "requires": {
-            "jake": "^10.6.1"
-          }
-        }
       }
     },
     "emoji-regex": {
@@ -8173,9 +8164,9 @@
       "dev": true
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "mongodb": {
       "version": "4.5.0",
@@ -8277,9 +8268,9 @@
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.3.tgz",
-      "integrity": "sha512-AXP18u4pidSZ1xYXRDPY/8jdv3RAozIt/WLNR/MBGZAz+xjtlr90RvCnsvHQRiXyWliZF/CpytExp32UU67/SA==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.10.tgz",
+      "integrity": "sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==",
       "requires": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -8500,9 +8491,9 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "passport": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.2.tgz",
-      "integrity": "sha512-w9n/Ot5I7orGD4y+7V3EFJCQEznE5RxHamUxcqLT2QoJY0f2JdN8GyHonYFvN0Vz+L6lUJfVhrk2aZz2LbuREw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.5.3.tgz",
+      "integrity": "sha512-gGc+70h4gGdBWNsR3FuV3byLDY6KBTJAIExGFXTpQaYfbbcHCBlRRKx7RBQSpqEqc5Hh2qVzRs7ssvSfOpkUEA==",
       "requires": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@sentry/node": "^6.19.2",
+    "@snyk/protect": "^1.984.0",
     "body-parser": "^1.19.2",
     "browser-detect": "^0.2.28",
     "chunk": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -72,15 +72,15 @@
   },
   "scripts": {
     "compile": "rm -rf dist/ && tsc",
-    "start": "node --max-old-space-size=8192 dist/src/app",
+    "start": "node --max-old-space-size=4096 dist/src/app",
     "pm2": "pm2 start dist/src/app.js --name 'DEL'",
     "css-compile": "sh ./scripts/css_build.sh",
     "setup": "node scripts/setup",
     "snyk-protect": "snyk-protect",
     "prepare": "npm run snyk-protect",
     "dev": "nodemon --exec \"tsc && fuser -k 3001/tcp && node dist/src/app.js\" --ext ts",
-    "update": "npm run compile && pm2 restart 1",
-    "updatel": "npm run compile && pm2 restart 1 && pm2 logs 1"
+    "update": "npm run compile && pm2 restart DEL",
+    "updatel": "npm run compile && pm2 restart DEL && pm2 logs DEL"
   },
   "repository": {
     "type": "git",

--- a/src/Routes/autosync.ts
+++ b/src/Routes/autosync.ts
@@ -168,7 +168,7 @@ router.get('/servers', async (req, res) => {
             target: id,
             date: Date.now(),
             reason: "Failed to autosync server, assuming the invite is invalid.",
-            reasonType: 0 // again, assuming 0 is the only option here
+            reasonType: 5
         });
 
         await serverCache.deleteServer(id);
@@ -268,7 +268,7 @@ router.get('/templates', async (req, res) => {
             target: id,
             date: Date.now(),
             reason: "Unknown server template (10057)",
-            reasonType: 0 // since this is the only option i guess? - AJ
+            reasonType: 4
         });
 
         await templateCache.deleteTemplate(id);

--- a/src/Routes/bots.ts
+++ b/src/Routes/bots.ts
@@ -616,7 +616,7 @@ router.post(
                     }
                 } as delBot);
 
-                (await discord.channels.logs).send(
+                discord.channels.logs.send(
                     `${settings.emoji.add} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${req.user.id
@@ -1629,7 +1629,7 @@ router.post(
                 });
                 await botCache.updateBot(req.params.id);
 
-                (await discord.channels.logs).send(
+                discord.channels.logs.send(
                     `${settings.emoji.edit} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${req.user.id
@@ -2087,7 +2087,7 @@ router.get(
                 req: req
             });
 
-        (await discord.channels.logs).send(
+        discord.channels.logs.send(
             `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${req.user.id
@@ -2147,7 +2147,7 @@ router.get(
                 req: req
             });
 
-        (await discord.channels.logs).send(
+        discord.channels.logs.send(
             `${settings.emoji.archive} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${req.user.id
@@ -2213,7 +2213,7 @@ router.get(
                 req: req
             });
 
-        (await discord.channels.logs).send(
+        discord.channels.logs.send(
             `${settings.emoji.hide} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${req.user.id
@@ -2278,7 +2278,7 @@ router.get(
                 req: req
             });
 
-        (await discord.channels.logs).send(
+        discord.channels.logs.send(
             `${settings.emoji.unhide} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${req.user.id
@@ -2937,7 +2937,7 @@ router.post(
                 });
                 await botCache.updateBot(req.params.id);
 
-                (await discord.channels.logs).send(
+                await discord.channels.logs.send(
                     `${settings.emoji.resubmit} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${req.user.id
@@ -3027,7 +3027,7 @@ router.get(
             }
         );
 
-        (await discord.channels.logs).send(
+        await discord.channels.logs.send(
             `${settings.emoji.check} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${req.user.id
@@ -3060,7 +3060,7 @@ router.get(
                 .add(settings.roles.developer, "User's bot was just approved.")
                 .catch(async (e) => {
                     console.error(e);
-                    (await discord.channels.alerts).send(
+                    discord.channels.alerts.send(
                         `${settings.emoji.error} Failed giving <@${bot.owner.id}> \`${bot.owner.id}\` the role **Bot Developer** upon one of their bots being approved.`
                     );
                 });
@@ -3071,7 +3071,7 @@ router.get(
                 .add(settings.roles.bot, "Bot was approved on the website.")
                 .catch(async (e) => {
                     console.error(e);
-                    (await discord.channels.alerts).send(
+                    discord.channels.alerts.send(
                         `${settings.emoji.error} Failed giving <@${bot._id}> \`${bot._id}\` the role **Bot** upon being approved on the website.`
                     );
                 });
@@ -3082,7 +3082,7 @@ router.get(
                 .kick("Bot was approved on the website.")
                 .catch(async (e) => {
                     console.error(e);
-                    (await discord.channels.alerts).send(
+                    discord.channels.alerts.send(
                         `${settings.emoji.error} Failed kicking <@${bot._id}> \`${bot._id}\` from the Testing Server on approval.`
                     );
                 });
@@ -3140,7 +3140,7 @@ router.get(
                 )
                 .catch(async (e) => {
                     console.error(e);
-                    (await discord.channels.alerts).send(
+                    discord.channels.alerts.send(
                         `${settings.emoji.error} Failed giving <@${botMember.id}> \`${botMember.id}\` the role **Premium Bot** upon being given premium on the website.`
                     );
                 });
@@ -3352,7 +3352,7 @@ router.post(
         embed.setDescription(req.body.reason);
         embed.setURL(`${settings.website.url}/bots/${bot._id}`);
 
-        (await discord.channels.logs).send({
+        discord.channels.logs.send({
             content: `${settings.emoji.cross} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${req.user.id
@@ -3507,7 +3507,7 @@ router.post(
         embed.setDescription(req.body.reason);
         embed.setURL(`${settings.website.url}/bots/${bot._id}`);
 
-        (await discord.channels.logs).send({
+        discord.channels.logs.send({
             content: `${settings.emoji.unapprove} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${req.user.id
@@ -3664,7 +3664,7 @@ router.post(
         embed.setDescription(req.body.reason);
         embed.setURL(`${settings.website.url}/bots/${bot._id}`);
 
-        (await discord.channels.logs).send({
+        discord.channels.logs.send({
             content: `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${req.user.id
@@ -3811,7 +3811,7 @@ router.post(
         embed.setDescription(req.body.reason);
         embed.setURL(`${settings.website.url}/bots/${bot._id}`);
 
-        (await discord.channels.logs).send({
+        discord.channels.logs.send({
             content: `${settings.emoji.hide} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${req.user.id
@@ -3885,7 +3885,7 @@ router.get(
             }
         );
 
-        (await discord.channels.logs).send(
+        discord.channels.logs.send(
             `${settings.emoji.unhide} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${req.user.id

--- a/src/Routes/index.ts
+++ b/src/Routes/index.ts
@@ -34,7 +34,7 @@ const router = express.Router();
 const nickSorter = (a, b) =>
     (a.nick || a.user.username).localeCompare(b.nick || b.user.username);
 function sortAll() {
-    let members = (async () => { return (await discord.guilds.main).members }).call(this) as GuildMemberManager;
+    let members = discord.guilds.main.members as GuildMemberManager;
     if (!members) throw new Error("Fetching members failed!");
     const staff: GuildMember[] = [],
         donators: GuildMember[] = [],

--- a/src/Routes/index.ts
+++ b/src/Routes/index.ts
@@ -27,14 +27,14 @@ import * as serverCache from "../Util/Services/serverCaching.js";
 import * as templateCache from "../Util/Services/templateCaching.js";
 import * as discord from "../Util/Services/discord.js";
 import { variables } from "../Util/Function/variables.js";
-import type { GuildMember } from "discord.js";
+import type { Guild, GuildMember, GuildMemberManager } from "discord.js";
 
 const router = express.Router();
 
 const nickSorter = (a, b) =>
     (a.nick || a.user.username).localeCompare(b.nick || b.user.username);
 function sortAll() {
-    let members = discord.guilds.main.members;
+    let members = (async () => { return (await discord.guilds.main).members }).call(this) as GuildMemberManager;
     if (!members) throw new Error("Fetching members failed!");
     const staff: GuildMember[] = [],
         donators: GuildMember[] = [],
@@ -53,10 +53,10 @@ function sortAll() {
             member.rank = admin
                 ? "admin"
                 : assistant
-                ? "assistant"
-                : mod
-                ? "mod"
-                : null;
+                    ? "assistant"
+                    : mod
+                        ? "mod"
+                        : null;
             const user = discord.bot.users.cache.get(member.id);
             member.avatar = user.avatar;
             member.username = user.username;
@@ -237,7 +237,10 @@ router.get("/servers", variables, async (req: Request, res: Response) => {
 
     if (!req.query.page) req.query.page = "1";
 
-    const servers = (await serverCache.getAllServers()).filter(
+    const servers = (await serverCache.getAllServers()).slice(
+        15 * Number(req.query.page) - 15,
+        15 * Number(req.query.page)
+    ).filter(
         ({ _id, status }) => status && !status.reviewRequired
     );
 
@@ -246,10 +249,7 @@ router.get("/servers", variables, async (req: Request, res: Response) => {
         subtitle: res.__("common.servers.subtitle"),
         req,
         servers,
-        serversPgArr: servers.slice(
-            15 * Number(req.query.page) - 15,
-            15 * Number(req.query.page)
-        ),
+        serversPgArr: servers,
         page: req.query.page,
         pages: Math.ceil(servers.length / 15)
     });

--- a/src/Routes/servers.ts
+++ b/src/Routes/servers.ts
@@ -45,6 +45,7 @@ import { ParamsDictionary } from "express-serve-static-core";
 import { ParsedQs } from "qs";
 const md = new mdi
 const router = express.Router();
+let reviewRequired = false; // Needs to be outside of the functions or it cannot be referenced outside of x function - AJ
 
 function serverType(bodyType: string): number {
     let type: serverReasons = parseInt(bodyType);
@@ -81,7 +82,6 @@ function tagHandler(req: express.Request<ParamsDictionary, any, any, ParsedQs, R
     if (req.body.contCreat === true) tags.push("Content Creation");
     if (req.body.nsfw === true) tags.push("NSFW");
 
-    let reviewRequired = false;
     if (req.body.lgbt === true) {
         tags.push("LGBT");
         if (server) {
@@ -293,7 +293,7 @@ router.post(
                     }
                 } as delServer);
 
-                await discord.channels.logs.send(
+                (await discord.channels.logs).send(
                     `${settings.emoji.add} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -702,7 +702,7 @@ router.post(
                     }
                 );
 
-                await discord.channels.logs.send(
+                (await discord.channels.logs).send(
                     `${settings.emoji.edit} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -935,7 +935,7 @@ router.post(
         embed.setURL(`${settings.website.url}/servers/${server._id}`);
         embed.setFooter("It will still be shown as a normal server, it was declined from being listed as an LGBT community.");
 
-        await discord.channels.logs.send({
+        (await discord.channels.logs).send({
             content: `${settings.emoji.cross} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${
@@ -1029,7 +1029,7 @@ router.get(
 
         await serverCache.updateServer(req.params.id);
 
-        await discord.channels.logs.send(
+        (await discord.channels.logs).send(
                 `${settings.emoji.check} **${functions.escapeFormatting(
                     req.user.db.fullUsername
                 )}** \`(${
@@ -1091,7 +1091,7 @@ router.get(
                 req
             });
 
-        await discord.channels.logs.send(
+        (await discord.channels.logs).send(
             `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${
@@ -1202,7 +1202,7 @@ router.post(
         embed.setTitle("Reason");
         embed.setDescription(req.body.reason);
 
-        await discord.channels.logs.send({
+        (await discord.channels.logs).send({
             content: `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${

--- a/src/Routes/servers.ts
+++ b/src/Routes/servers.ts
@@ -293,7 +293,7 @@ router.post(
                     }
                 } as delServer);
 
-                (await discord.channels.logs).send(
+                discord.channels.logs.send(
                     `${settings.emoji.add} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -702,7 +702,7 @@ router.post(
                     }
                 );
 
-                (await discord.channels.logs).send(
+                discord.channels.logs.send(
                     `${settings.emoji.edit} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -935,7 +935,7 @@ router.post(
         embed.setURL(`${settings.website.url}/servers/${server._id}`);
         embed.setFooter("It will still be shown as a normal server, it was declined from being listed as an LGBT community.");
 
-        (await discord.channels.logs).send({
+        discord.channels.logs.send({
             content: `${settings.emoji.cross} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${
@@ -1029,7 +1029,7 @@ router.get(
 
         await serverCache.updateServer(req.params.id);
 
-        (await discord.channels.logs).send(
+        discord.channels.logs.send(
                 `${settings.emoji.check} **${functions.escapeFormatting(
                     req.user.db.fullUsername
                 )}** \`(${
@@ -1091,7 +1091,7 @@ router.get(
                 req
             });
 
-        (await discord.channels.logs).send(
+        discord.channels.logs.send(
             `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${
@@ -1202,7 +1202,7 @@ router.post(
         embed.setTitle("Reason");
         embed.setDescription(req.body.reason);
 
-        (await discord.channels.logs).send({
+        discord.channels.logs.send({
             content: `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${

--- a/src/Routes/staff.ts
+++ b/src/Routes/staff.ts
@@ -140,7 +140,7 @@ router.get(
             .toArray();
 
         for (const bot of bots) {
-            (await discord.guilds.main).members.cache.has(bot._id)
+            discord.guilds.main.members.cache.has(bot._id)
                 ? (bot.inServer = true)
                 : (bot.inServer = false);
         }

--- a/src/Routes/staff.ts
+++ b/src/Routes/staff.ts
@@ -140,7 +140,7 @@ router.get(
             .toArray();
 
         for (const bot of bots) {
-            discord.guilds.main.members.cache.has(bot._id)
+            (await discord.guilds.main).members.cache.has(bot._id)
                 ? (bot.inServer = true)
                 : (bot.inServer = false);
         }

--- a/src/Routes/staff.ts
+++ b/src/Routes/staff.ts
@@ -172,8 +172,8 @@ router.get(
             .sort({ date: -1 })
             .allowDiskUse()
             .toArray()) as auditLog[]).filter(
-            ({ type }) => type !== "GAME_HIGHSCORE_UPDATE"
-        );
+                ({ type }) => type !== "GAME_HIGHSCORE_UPDATE"
+            );
 
         if (!req.query.page) req.query.page = "1";
 
@@ -188,7 +188,6 @@ router.get(
         }
 
         res.locals.premidPageInfo = res.__("premid.staff.audit");
-
         res.render("templates/staff/audit", {
             title: res.__("page.staff.audit"),
             subtitle: res.__("page.staff.audit.subtitle"),
@@ -197,7 +196,7 @@ router.get(
             logsPgArr: iteratedLogs,
             page: req.query.page,
             pages: Math.ceil(logs.length / 15),
-            functions
+            functions,
         });
     }
 );

--- a/src/Routes/templates.ts
+++ b/src/Routes/templates.ts
@@ -196,7 +196,7 @@ router.post(
                     }
                 } as delTemplate);
 
-                await discord.channels.logs.send(
+                (await discord.channels.logs).send(
                     `${settings.emoji.add} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -563,7 +563,7 @@ router.post(
                     }
                 );
 
-                await discord.channels.logs.send(
+                (await discord.channels.logs).send(
                     `${settings.emoji.edit} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -701,7 +701,7 @@ router.get(
                 req
             });
 
-        await discord.channels.logs.send(
+        (await discord.channels.logs).send(
             `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${
@@ -815,7 +815,7 @@ router.post(
         embed.setTitle("Reason");
         embed.setDescription(req.body.reason);
 
-        await discord.channels.logs.send({
+        (await discord.channels.logs).send({
             content: `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${

--- a/src/Routes/templates.ts
+++ b/src/Routes/templates.ts
@@ -196,7 +196,7 @@ router.post(
                     }
                 } as delTemplate);
 
-                (await discord.channels.logs).send(
+                discord.channels.logs.send(
                     `${settings.emoji.add} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -563,7 +563,7 @@ router.post(
                     }
                 );
 
-                (await discord.channels.logs).send(
+                discord.channels.logs.send(
                     `${settings.emoji.edit} **${functions.escapeFormatting(
                         req.user.db.fullUsername
                     )}** \`(${
@@ -701,7 +701,7 @@ router.get(
                 req
             });
 
-        (await discord.channels.logs).send(
+        discord.channels.logs.send(
             `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${
@@ -815,7 +815,7 @@ router.post(
         embed.setTitle("Reason");
         embed.setDescription(req.body.reason);
 
-        (await discord.channels.logs).send({
+        discord.channels.logs.send({
             content: `${settings.emoji.delete} **${functions.escapeFormatting(
                 req.user.db.fullUsername
             )}** \`(${

--- a/src/Util/Function/main.ts
+++ b/src/Util/Function/main.ts
@@ -21,12 +21,14 @@ import * as botCache from "../Services/botCaching.js";
 import * as userCache from "../Services/userCaching.js";
 import { URL } from "url";
 import { OAuth2Scopes } from "discord-api-types/v10";
-
 export const escapeFormatting = (text: string) => {
     const unescaped = text.replace(/\\(\*|_|`|~|\\)/g, "$1");
     const escaped = unescaped.replace(/(\*|_|`|~|\\)/g, "\\$1");
     return escaped;
 };
+// this seems stupid but apparently it should work
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
 
 const regions = {
     "us-west": "US West",
@@ -118,8 +120,7 @@ export function parseDate(__, locale: string, rawDate: number): string {
     if (rawDate === 0) return "???";
 
     const date = new Date(rawDate);
-    const dateFormat = require(`../../../../node_modules/del-i18n/website/${locale}.json`);
-
+    const dateFormat = require(`../../../../node_modules/del-i18n/website/${locale}.json`)
     if (dateFormat["common.dateFormat"].includes("{{amPM}}")) {
         let amPM: string;
         let hour = date.getUTCHours();
@@ -228,7 +229,7 @@ export function parseAudit(__, auditType: string): auditType {
             returnType.name = __("page.staff.audit.type.MOD_HIDE_BOT");
             returnType.icon = "far fa-eye-slash has-text-white";
             break;
-        case "MOD_UNHIDE_BOT":  
+        case "MOD_UNHIDE_BOT":
             returnType.name = __("page.staff.audit.type.MOD_UNHIDE_BOT");
             returnType.icon = "far fa-eye has-text-white";
             break;

--- a/src/Util/Services/banned.ts
+++ b/src/Util/Services/banned.ts
@@ -17,6 +17,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+import { Collection, GuildBan } from "discord.js";
 import { guilds } from "./discord.js";
 
 export async function check(user: string): Promise<boolean> {
@@ -26,8 +27,8 @@ export async function check(user: string): Promise<boolean> {
 
 export async function updateBanlist() {
     await global.redis?.del("bans");
-    const bans = await guilds.main.bans.fetch().catch(e => console.error(e));
-    await global.redis?.hmset(
+    const bans = await (await guilds.main).bans.fetch().catch(e => console.error(e)) as Collection<string, GuildBan>;
+    if(bans.size > 0) await global.redis?.hmset(
         "bans",
         ...bans.map((ban) => [ban.user.id, true])
     );

--- a/src/Util/Services/banned.ts
+++ b/src/Util/Services/banned.ts
@@ -27,7 +27,7 @@ export async function check(user: string): Promise<boolean> {
 
 export async function updateBanlist() {
     await global.redis?.del("bans");
-    const bans = await (await guilds.main).bans.fetch().catch(e => console.error(e)) as Collection<string, GuildBan>;
+    const bans = await guilds.main.bans.fetch().catch(e => console.error(e)) as Collection<string, GuildBan>;
     if(bans.size > 0) await global.redis?.hmset(
         "bans",
         ...bans.map((ban) => [ban.user.id, true])

--- a/src/Util/Services/botCaching.ts
+++ b/src/Util/Services/botCaching.ts
@@ -18,7 +18,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 const prefix = "bots";
-
 export async function getBot(id: string): Promise<delBot> {
     const bot = await global.redis?.hget(prefix, id);
     if (!bot) return;
@@ -59,6 +58,7 @@ export async function uploadBots() {
         prefix,
         ...botsDB.map((bot: delBot) => [bot._id, JSON.stringify(bot)])
     );
+
 }
 
 export async function deleteBot(id: string) {

--- a/src/Util/Services/discord.ts
+++ b/src/Util/Services/discord.ts
@@ -106,7 +106,7 @@ bot.on("guildMemberAdd", async (member) => {
     await global.redis?.hmset(
         prefix,
         member.id,
-        member.presence.status || PresenceUpdateStatus.Offline
+        member.presence ? member.presence.status || PresenceUpdateStatus.Offline : PresenceUpdateStatus.Offline
     );
 
     if (member.guild.id === settings.guild.main) await postMetric();


### PR DESCRIPTION
All changes were tested *except* for autosync auto deletion for templates and servers. I'll need someone to verify that works, it should though. 

Changes:
- Edited a number of queries that were being run for counts, to only attempt to fetch the estimated mongodb count, vs actually fetching the items, putting them into an array, and checking the length. 
- Changed the interval in which "daily" metrics postings occurred, to actually be a day (23.8h to be exact) and not be posting every **5 seconds**. This was... causing a lot of problems
- Changed how the site launches, it was possible for it to become "stuck" if it happened to execute quickly- it would end up waiting for the bot to emit ready. but it never got to the point where the bot could emit ready, as it held the process up.
- If the datadog variable is an empty string, or null in the settings.json file, don't attempt to log metrics
- Changed a few files to no longer call **all** databases, even when there is a switch operator to control what metrics need to be updated. Ie: Don't waste time and resources querying things that aren't being used currently
- For automatic banlist updating, and this will only impact servers with no bans, or development testing- if there are no bans to be found, don't attempt to set a null value in redis
- For express, the cookie-session module wants an array of strings now, even though it isn't mentioned in the docs, I tried it a few times. I just tossed the settings string into an array to make it happy.

TLDR; The site shouldn't hang and die anymore, at least it didn't in my testing. I also am assuming any memory leak that did exist, has been fixed with these changes (from what I can see anyway, and the stats, this is correct).