### PR TITLE
build: add the `.js` extension on `start` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "scripts": {
     "compile": "rm -rf dist/ && tsc",
-    "start": "node --max-old-space-size=8192 dist/src/app",
+    "start": "node --max-old-space-size=8192 dist/src/app.js",
     "pm2": "pm2 start dist/src/app.js --name 'DEL'",
     "css-compile": "sh ./scripts/css_build.sh",
     "setup": "node scripts/setup",


### PR DESCRIPTION
This pull request adds the missing `.js` extension in the `start` script, because Node assumes that `app` is a directory when it is a file, hence the `app.js` was added. Which finally becomes `node --max-old-space-size=8192 dist/src/app.js`.