### PR TITLE
Remove issue displaying non-implemented my data option under user's profile dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "del-website",
-  "version": "v5.6.9-Release",
+  "version": "v5.6.10-Release",
   "description": "Discord Extreme List, Discord's unbiased list! Official source code for the DEL v5 website!",
   "main": "dist/src/app.js",
   "directories": {

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -366,13 +366,13 @@
                             </span>
                             <span><%= __("common.nav.me.preferences") %></span>
                         </a>
-                        <a class="navbar-item" href="<%= linkPrefix %>/users/account/data" tabindex="0">
+                        <!-- <a class="navbar-item" href="<%= linkPrefix %>/users/account/data" tabindex="0">
                             <span class="icon iconalign">
                                 <i class="fad fa-database" aria-hidden="true"></i>
                             </span>
                             <span><%= __("common.nav.me.data") %></span>
-                        </a>
-                        <hr class="navbar-divider">
+                        </a> -->
+                        <hr class="navbar-divider"> 
                         <a class="navbar-item" href="<%= linkPrefix %>/bots/submit" tabindex="0">
                             <span class="icon iconalign">
                                 <i class="fad fa-robot" aria-hidden="true"></i>


### PR DESCRIPTION
Removes it pretty much because the backend endpoints for it are commented out, there are no strings for it, so it just displays as "common.nav.me.data", which is silly, and as it has no backend implementation currently it just 404s. So, it's being temporarily removed since it has no purpose and just looks bad on prod.