### PR TITLE
Fixes transfer ownership feature not working, removes hardcoded string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "del-website",
-  "version": "v5.6.14-Release",
+  "version": "v5.6.15-Release",
   "description": "Discord Extreme List, Discord's unbiased list! Official source code for the DEL v5 website!",
   "main": "dist/src/app.js",
   "directories": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ dependencies:
     version: 4.3.7
   del-i18n:
     specifier: github:discordextremelist/i18n
-    version: github.com/discordextremelist/i18n/db58c5043e697bca51b9ee4890bd526d7878b0a8
+    version: github.com/discordextremelist/i18n/a8e4bdb9f3cd604ea0d95ed73ca7c5fc7dc7b1a3
   discord.js:
     specifier: ^14.11.0
     version: 14.18.0
@@ -6730,8 +6730,8 @@ packages:
       - yaml
     dev: false
 
-  github.com/discordextremelist/i18n/db58c5043e697bca51b9ee4890bd526d7878b0a8:
-    resolution: {tarball: https://codeload.github.com/discordextremelist/i18n/tar.gz/db58c5043e697bca51b9ee4890bd526d7878b0a8}
+  github.com/discordextremelist/i18n/a8e4bdb9f3cd604ea0d95ed73ca7c5fc7dc7b1a3:
+    resolution: {tarball: https://codeload.github.com/discordextremelist/i18n/tar.gz/a8e4bdb9f3cd604ea0d95ed73ca7c5fc7dc7b1a3}
     name: del-i18n
     version: 0.0.0
     dev: false

--- a/src/Routes/bots.ts
+++ b/src/Routes/bots.ts
@@ -873,11 +873,11 @@ router.post(
             .findOne({ _id: req.body.newOwner });
 
         if (!newOwnerExists)
-            return res.status(403).render("status", {
+            return res.status(422).render("status", {
                 res,
                 title: res.__("common.error"),
-                subtitle: res.__("common.error.user.404"),
-                status: 404,
+                subtitle: res.__("common.error.bot.transferOwnership.422"),
+                status: 422,
                 type: "Error",
                 req
             });

--- a/views/partials/cards/botCard.ejs
+++ b/views/partials/cards/botCard.ejs
@@ -61,7 +61,7 @@
                     %>
                         <div class="control" style="padding-bottom: 1em;">
                             <div class="tags has-addons">
-                              <span class="tag is-dark">Added to the queue</span>
+                              <span class="tag is-dark"><%= __("page.staff.queue.addedAtTime") %></span>
                               <span class="tag <%= statusClass %>"><%= timeString %> (UTC), <%= dateString %></span>
                             </div>
                         </div>

--- a/views/templates/bots/view.ejs
+++ b/views/templates/bots/view.ejs
@@ -741,7 +741,7 @@
                     <br />
                     <div class="field">
                         <p class="control has-icons-left has-icons-right">
-                            <input class="input is-rounded" type="text" name="vanity" placeholder="<%= __("page.bots.transferOwner.placeholder") %>" required>
+                            <input class="input is-rounded" type="text" name="newOwner" placeholder="<%= __("page.bots.transferOwner.placeholder") %>" required>
                             <span class="icon is-small is-left">
                                 <i aria-hidden="true" class="fas fa-link"></i>
                             </span>


### PR DESCRIPTION
## 1. Transfer ownership feature not working

The transfer ownership feature was not working as intended, as in the `<form>` on the ejs file, the name was set to "vanity" instead of "newOwner". This lead to "newOwner" always being undefined, thus resulting in a "this user does not exist" error.

Previously, an invalid user ID used to throw the same error message as 404ing a user page, but it now returns a more clear and accurate error message. The new string is `common.error.bot.transferOwnership.422`.

## 2. Removes hardcoded string

The string for when a bot was added to the queue (on date), was hardcoded in when the update was released. This has been fixed and now uses the string `page.staff.queue.addedAtTime`.